### PR TITLE
Automate frontend and backend deployment to railway

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,21 @@
+name: Deploy Backend to Railway
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'server/**'
+
+jobs:
+  deploy-backend:
+    runs-on: ubuntu-latest
+    container: ghcr.io/railwayapp/cli:latest
+    env:
+      SVC_ID: 0a49cfcf-d7a0-43fb-b0ce-691a24074d64
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Deploy Backend to Railway
+        run: railway up --service=${{ env.SVC_ID }} --detach

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,30 @@
+name: Deploy Frontend to Railway
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'index.html'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.ts'
+      - 'tsconfig*.json'
+      - 'tailwind.config.js'
+      - 'postcss.config.js'
+      - 'railway.json'
+
+jobs:
+  deploy-frontend:
+    runs-on: ubuntu-latest
+    container: ghcr.io/railwayapp/cli:latest
+    env:
+      SVC_ID: ced5a086-32ca-4d0c-9830-b0892243c4ee
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Deploy Frontend to Railway
+        run: railway up --service=${{ env.SVC_ID }}


### PR DESCRIPTION
Add GitHub Actions workflows for path-based automatic deployment of frontend and backend services to Railway on pushes to `main`.

These workflows ensure that only relevant services are deployed when changes occur in their respective directories, preventing unnecessary builds. The backend deployment also uses the `--detach` flag for improved handling of long-running processes.

---

[Open in Web](https://cursor.com/agents?id=bc-cdb3c748-31c3-4c97-b10b-bb0ce6148070) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cdb3c748-31c3-4c97-b10b-bb0ce6148070) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)