### PR TITLE
Manually link kids to parent child relationships

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -392,6 +392,23 @@ class ApiClient {
     return this.request(`/games/manual-players/search?q=${encodeURIComponent(query)}`);
   }
 
+  async getAllManualPlayers() {
+    return this.request('/games/admin/manual-players');
+  }
+
+  async linkManualPlayer(manualPlayerId: string, userId: string) {
+    return this.request(`/games/admin/manual-players/${manualPlayerId}/link`, {
+      method: 'PATCH',
+      body: JSON.stringify({ userId }),
+    });
+  }
+
+  async unlinkManualPlayer(manualPlayerId: string) {
+    return this.request(`/games/admin/manual-players/${manualPlayerId}/unlink`, {
+      method: 'PATCH',
+    });
+  }
+
   // Game Stats endpoints
   async addPlayerStat(gameId: string, playerId: string, statType: string, value?: number, quarter?: number, timeMinute?: number) {
     return this.request(`/games/${gameId}/players/${playerId}/stats`, {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add admin functionality to link manual players to registered users and integrate them into parent-child relationships.

---

[Open in Web](https://cursor.com/agents?id=bc-013a0088-1a4e-40b7-aef6-eda799704d1f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-013a0088-1a4e-40b7-aef6-eda799704d1f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)