### PR TITLE
Fix backend deployment directory in GitHub action

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -18,4 +18,5 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Deploy Backend to Railway
+        working-directory: ./server
         run: railway up --service=${{ env.SVC_ID }} --detach

--- a/server/railway.json
+++ b/server/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "npm run build"
+  },
+  "deploy": {
+    "startCommand": "npm start",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 100,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
Correct backend deployment by specifying the working directory and adding a dedicated Railway configuration.

The backend API was not coming up because the GitHub Action was running `railway up` from the root directory instead of the `server/` directory where the backend code resides. This PR ensures the deployment command executes from the correct location and provides a dedicated `railway.json` for the backend with appropriate build, start, and health check configurations.

---

[Open in Web](https://cursor.com/agents?id=bc-958d615b-6896-4027-9763-c6e16ca74260) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-958d615b-6896-4027-9763-c6e16ca74260) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)